### PR TITLE
Fix typo in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Really Simple Syndication (RSL)
+# Really Simple Licensing (RSL)
 
 **Really Simple Licensing (RSL)** is an open, XML-based standard that enables publishers and platforms to define **machine-readable licensing and usage terms** for digital assets on the web.
 


### PR DESCRIPTION
README heading said Syndication (as in RSS) not Licensing (as in RSL)